### PR TITLE
Add icons in action description

### DIFF
--- a/Scripts/CardUtils.gd
+++ b/Scripts/CardUtils.gd
@@ -87,3 +87,9 @@ static func get_icon(icon: IconType):
 
 static func get_icon_scale(icon: IconType):
 	return icon_scale[icon]
+
+static func get_icon_type_from_name(name: String):
+	for icon_name in IconType.keys():
+		if name.to_lower() == icon_name.to_lower():
+			return IconType[icon_name]
+	return null

--- a/Scripts/Editor/BaseAction.gd
+++ b/Scripts/Editor/BaseAction.gd
@@ -67,7 +67,38 @@ func toggle_hologram(toggle: bool):
 
 func on_description_change(new_description):
 	data.description = new_description
-	description_text.text = data.description
+	
+	var parsed_description = ""
+	
+	var in_tag = false
+	var tag = ""
+	
+	for ch in new_description:
+		if ch == '[':
+			in_tag = true
+		elif ch == ']':
+			in_tag = false
+			
+			var icon_type = CardUtils.get_icon_type_from_name(tag)
+			if icon_type == null:
+				parsed_description += "[" + tag + "]"
+			else:
+				var icon: Resource = CardUtils.get_icon(icon_type)
+				var icon_scale = CardUtils.get_icon_scale(icon_type) / 2
+				
+				parsed_description += "[img height=" + str(icon_scale) + "]" + icon.resource_path + "[/img]"
+			
+			tag = ""
+		else:
+			if in_tag:
+				tag += ch
+			else :
+				parsed_description += ch
+	
+	if in_tag:
+		parsed_description += "[" + tag
+	
+	description_text.text = parsed_description
 
 func on_toggle_icon_bar(toggle: bool):
 	data.hasIconBar = toggle


### PR DESCRIPTION
Adds a new function to get the (case insensitive) icon type from its name

Adds a parser in on_description_change that parses the raw text and replaces icon names between a [ and a ] with the icon richtext code. This will not show up in the text box, but will show up in the rendered card or the card in the list. Incomplete tags and anything that isn't an icon are ignored.